### PR TITLE
REFACT - Python 3 compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
+**/*.egg-info
 *.pyc
-metsvalidator/__pycache__/*.pyc
 Pipfile
 Pipfile.lock
 history-eark.txt
 sw/*
-venv/*
-venv/bin/*
-
-
+**/venv
+**/.venv

--- a/metsvalidator/MetsRootValidator.py
+++ b/metsvalidator/MetsRootValidator.py
@@ -15,7 +15,7 @@
 #
 #CSIP3: The Information Package folder CAN be compressed (for example by using TAR or ZIP)
 #
-#CSIP4: The Information Package folder MUST include a metadata file named METS.xml, which includes information about the identity and structure of the package and its components 
+#CSIP4: The Information Package folder MUST include a metadata file named METS.xml, which includes information about the identity and structure of the package and its components
 #
 #CSIP5: The Information Package folder MUST include a folder named metadata, which MUST include at least all metadata relevant for the whole package
 #
@@ -27,9 +27,9 @@
 #
 #CSIP9: The Information Package folder MUST include a folder named representations
 #
-#CSIP10: The representations folder MUST include a sub-folder for each individual representation (i.e. the “representation folder”) named with a string uniquely identifying the representation within the scope of the package (for example the name of the representation and/or its creation date could be good examples for an representation sub-folder) 
+#CSIP10: The representations folder MUST include a sub-folder for each individual representation (i.e. the “representation folder”) named with a string uniquely identifying the representation within the scope of the package (for example the name of the representation and/or its creation date could be good examples for an representation sub-folder)
 #
-#CSIP11: The representation folder MUST include a sub-folder named data which includes all data constituting the representation 
+#CSIP11: The representation folder MUST include a sub-folder named data which includes all data constituting the representation
 #
 #CSIP12: The representation folder CAN include a metadata file named METS.xml which includes information about the identity and structure of the representation
 #
@@ -48,7 +48,7 @@ from lxml import isoschematron
 from lxml import etree
 
 def load_rules():
-    print ('Loading rules from XML file...')
+    print('Loading rules from XML file...')
 
 def main():
 
@@ -77,20 +77,20 @@ def main():
 
     # Parse schema
     sct_doc = etree.parse(f)
-    schematron = isoschematron.Schematron(sct_doc, store_report = True)
+    schematron = isoschematron.Schematron(sct_doc, store_report=True)
 
 
     # XML to validate
     notValid = io.StringIO('''\
-	<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-	    xmlns:mets="http://www.loc.gov/METS/" 
+	<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xmlns:mets="http://www.loc.gov/METS/"
 	    xmlns:xlink="http://www.w3.org/1999/xlink"
 	    xmlns:csip="DILCIS"
-	    OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182" 
-	    LABEL="Sample CS IP Information Package" 
-	    TYPE="Database" 
-	    csip:CONTENTTYPESPECIFICATION="SIARD3" 	
-	    PROFILE="http://www.eark-project.com/METS/IP.xml" 
+	    OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182"
+	    LABEL="Sample CS IP Information Package"
+	    TYPE="Database"
+	    csip:CONTENTTYPESPECIFICATION="SIARD3"
+	    PROFILE="http://www.eark-project.com/METS/IP.xml"
 	    xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd">
          </mets:mets>
         ''')

--- a/metsvalidator/MetsValidator.py
+++ b/metsvalidator/MetsValidator.py
@@ -15,7 +15,7 @@
 #
 #CSIP3: The Information Package folder CAN be compressed (for example by using TAR or ZIP)
 #
-#CSIP4: The Information Package folder MUST include a metadata file named METS.xml, which includes information about the identity and structure of the package and its components 
+#CSIP4: The Information Package folder MUST include a metadata file named METS.xml, which includes information about the identity and structure of the package and its components
 #
 #CSIP5: The Information Package folder MUST include a folder named metadata, which MUST include at least all metadata relevant for the whole package
 #
@@ -27,9 +27,9 @@
 #
 #CSIP9: The Information Package folder MUST include a folder named representations
 #
-#CSIP10: The representations folder MUST include a sub-folder for each individual representation (i.e. the “representation folder”) named with a string uniquely identifying the representation within the scope of the package (for example the name of the representation and/or its creation date could be good examples for an representation sub-folder) 
+#CSIP10: The representations folder MUST include a sub-folder for each individual representation (i.e. the “representation folder”) named with a string uniquely identifying the representation within the scope of the package (for example the name of the representation and/or its creation date could be good examples for an representation sub-folder)
 #
-#CSIP11: The representation folder MUST include a sub-folder named data which includes all data constituting the representation 
+#CSIP11: The representation folder MUST include a sub-folder named data which includes all data constituting the representation
 #
 #CSIP12: The representation folder CAN include a metadata file named METS.xml which includes information about the identity and structure of the representation
 #
@@ -65,7 +65,7 @@ def main():
 
     # Parse schema
     sct_doc = etree.parse(f)
-    schematron = isoschematron.Schematron(sct_doc, store_report = True)
+    schematron = isoschematron.Schematron(sct_doc, store_report=True)
 
     # XML to validate - validation will fail because sum of numbers
     # not equal to 100

--- a/metsvalidator/__init__.py
+++ b/metsvalidator/__init__.py
@@ -13,4 +13,3 @@
 # main package contents
 #"""Initialisation module for package, validates METS input in XML format."""
 #from . import mets_validator_impl
-

--- a/metsvalidator/mets_validator_impl.py
+++ b/metsvalidator/mets_validator_impl.py
@@ -15,7 +15,7 @@
 #
 #CSIP3: The Information Package folder CAN be compressed (for example by using TAR or ZIP)
 #
-#CSIP4: The Information Package folder MUST include a metadata file named METS.xml, which includes information about the identity and structure of the package and its components 
+#CSIP4: The Information Package folder MUST include a metadata file named METS.xml, which includes information about the identity and structure of the package and its components
 #
 #CSIP5: The Information Package folder MUST include a folder named metadata, which MUST include at least all metadata relevant for the whole package
 #
@@ -27,9 +27,9 @@
 #
 #CSIP9: The Information Package folder MUST include a folder named representations
 #
-#CSIP10: The representations folder MUST include a sub-folder for each individual representation (i.e. the “representation folder”) named with a string uniquely identifying the representation within the scope of the package (for example the name of the representation and/or its creation date could be good examples for an representation sub-folder) 
+#CSIP10: The representations folder MUST include a sub-folder for each individual representation (i.e. the “representation folder”) named with a string uniquely identifying the representation within the scope of the package (for example the name of the representation and/or its creation date could be good examples for an representation sub-folder)
 #
-#CSIP11: The representation folder MUST include a sub-folder named data which includes all data constituting the representation 
+#CSIP11: The representation folder MUST include a sub-folder named data which includes all data constituting the representation
 #
 #CSIP12: The representation folder CAN include a metadata file named METS.xml which includes information about the identity and structure of the representation
 #
@@ -56,18 +56,18 @@ from lxml import etree
 #    return validator_rules
 
 def load_xml(filename):
-    print ('Loading XML file:', filename)
-    xml_file = open(filename,"r")
+    print('Loading XML file:', filename)
+    xml_file = open(filename, "r")
     xml_content = xml_file.read()
     xml_file.close()
     return xml_content
 
 def validate(rules, sample_file):
     f = io.StringIO(rules)
-    
+
     # Parse schema
     sct_doc = etree.parse(f)
-    schematron = isoschematron.Schematron(sct_doc, store_report = True)
+    schematron = isoschematron.Schematron(sct_doc, store_report=True)
 
     # XML to validate
     sample = load_xml(sample_file)
@@ -111,20 +111,20 @@ def main():
 
     # Parse schema
     sct_doc = etree.parse(f)
-    schematron = isoschematron.Schematron(sct_doc, store_report = True)
+    schematron = isoschematron.Schematron(sct_doc, store_report=True)
 
 
     # XML to validate
     notValid = io.StringIO('''\
-	<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-	    xmlns:mets="http://www.loc.gov/METS/" 
+	<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xmlns:mets="http://www.loc.gov/METS/"
 	    xmlns:xlink="http://www.w3.org/1999/xlink"
 	    xmlns:csip="DILCIS"
-	    OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182" 
-	    LABEL="Sample CS IP Information Package" 
-	    TYPE="Database" 
-	    csip:CONTENTTYPESPECIFICATION="SIARD3" 	
-	    PROFILE="http://www.eark-project.com/METS/IP.xml" 
+	    OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182"
+	    LABEL="Sample CS IP Information Package"
+	    TYPE="Database"
+	    csip:CONTENTTYPESPECIFICATION="SIARD3"
+	    PROFILE="http://www.eark-project.com/METS/IP.xml"
 	    xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd">
          </mets:mets>
         ''')

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,9 @@ from setuptools import setup
 
 setup(
     name='mets-validator',
-    packages=['mets-validator'],
+    packages=['metsvalidator'],
     include_package_data=True,
     install_requires=[
         'lxml==3.7.3'
     ],
 )
-

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -13,4 +13,3 @@
 # main package contents
 #"""Initialisation module for package, validates METS input in XML format."""
 #from . import mets_validator_impl
-

--- a/test/base.py
+++ b/test/base.py
@@ -1,17 +1,21 @@
+"""
+    Base class for unit tests.
+"""
 import unittest
-from metsvalidator.mets_validator_impl import load_xml, validate
+from metsvalidator.mets_validator_impl import load_xml
 
-# In this class we test first the correct mets root element and then different error samples. 
+# In this class we test first the correct mets root element and then different error samples.
 # If validation error was detected - validation result should be False.
 class Base(unittest.TestCase):
-    """ Base class for tests of METS elements. This class defines a common 'setUp' method that initializes rules which are used in the various tests. """
+    """ Base class for tests of METS elements. This class defines a common
+    'setUp' method that initializes rules which are used in the various tests. """
 
     #SOURCES_PATH = "sources/"
 
     @classmethod
-    def setUpClass(self):
-        self.SOURCES_PATH = "sources/"
-        self.rules = load_xml(self.SOURCES_PATH+"mets_validator.xml")
+    def setUpClass(cls):
+        cls.SOURCES_PATH = "sources/"
+        cls.rules = load_xml(cls.SOURCES_PATH+"mets_validator.xml")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_file_premis.py
+++ b/test/test_file_premis.py
@@ -1,7 +1,11 @@
-from base import Base
+"""
+    Unit tests for PREMIS elements.
+"""
+from test.base import Base
 from metsvalidator.mets_validator_impl import validate
 
-# In this class we test first the correct mets file metadata element in PREMIS format and then different error samples. 
+# In this class we test first the correct mets file metadata element in
+# PREMIS format and then different error samples.
 # If validation error was detected - validation result should be False.
 class MetsFileMetadataPremisTestCase(Base):
     """ Tests for METS file metadata premis element """
@@ -97,6 +101,3 @@ class MetsFileMetadataPremisTestCase(Base):
     def test_csip79_check_file_premis_element_grp_file_flocat_loctype(self):
         validationResult, report = validate(self.rules, self.SOURCES_PATH+"mets_file_premis_element/mets_file_premis_element_grp_file_flocat_xlink_href_not_exists.xml")
         self.assertTrue(validationResult==True)
-
-
-

--- a/test/test_mets_administrative_metadata_premis.py
+++ b/test/test_mets_administrative_metadata_premis.py
@@ -1,7 +1,7 @@
-from base import Base
+from test.base import Base
 from metsvalidator.mets_validator_impl import validate
 
-# In this class we test first the correct mets administrative metadata element in PREMIS format and then different error samples. 
+# In this class we test first the correct mets administrative metadata element in PREMIS format and then different error samples.
 # If validation error was detected - validation result should be False.
 class MetsAdministrativeMetadataPremisTestCase(Base):
     """ Tests for METS administrative metadata premis element """
@@ -69,7 +69,3 @@ class MetsAdministrativeMetadataPremisTestCase(Base):
     def test_csip45_check_administrative_metadata_premis_element_rightsmd(self):
         validationResult, report = validate(self.rules, self.SOURCES_PATH+"mets_administrative_metadata_premis_element/mets_administrative_metadata_premis_element_rightsmd_not_exists.xml")
         self.assertTrue(validationResult==True)
-
-
-
-

--- a/test/test_mets_descriptive_metadata.py
+++ b/test/test_mets_descriptive_metadata.py
@@ -1,7 +1,7 @@
-from base import Base
+from test.base import Base
 from metsvalidator.mets_validator_impl import validate
 
-# In this class we test first the correct mets descriptive metadata element and then different error samples. 
+# In this class we test first the correct mets descriptive metadata element and then different error samples.
 # If validation error was detected - validation result should be False.
 class MetsDescriptiveMetadataTestCase(Base):
     """ Tests for METS descriptive metadata element """
@@ -79,5 +79,3 @@ class MetsDescriptiveMetadataTestCase(Base):
     def test_csip36_check_descriptive_metadata_core_checksumtype_validation(self):
         validationResult, report = validate(self.rules, self.SOURCES_PATH+"mets_descriptive_metadata_element/mets_descriptive_metadata_core_checksumtype_validation.xml")
         self.assertTrue(validationResult==True)
-
-

--- a/test/test_mets_header.py
+++ b/test/test_mets_header.py
@@ -1,7 +1,7 @@
-from base import Base
+from test.base import Base
 from metsvalidator.mets_validator_impl import validate
 
-# In this class we test first the correct mets header element and then different error samples. 
+# In this class we test first the correct mets header element and then different error samples.
 # If validation error was detected - validation result should be False.
 class MetsHeaderTestCase(Base):
     """ Tests for METS header element """
@@ -55,4 +55,3 @@ class MetsHeaderTestCase(Base):
     def test_csip19_check_header_agent_note_type_element(self):
         validationResult, report = validate(self.rules, self.SOURCES_PATH+"mets_header_element/mets_header_element_agent_note_type_not_exists.xml")
         self.assertTrue(validationResult==True)
-

--- a/test/test_mets_root.py
+++ b/test/test_mets_root.py
@@ -1,7 +1,7 @@
 from metsvalidator.mets_validator_impl import validate
-from base import Base
+from test.base import Base
 
-# In this class we test first the correct mets root element and then different error samples. 
+# In this class we test first the correct mets root element and then different error samples.
 # If validation error was detected - validation result should be False.
 class MetsRootTestCase(Base):
     """ Tests for METS root element """
@@ -36,4 +36,3 @@ class MetsRootTestCase(Base):
     def test_csip6_content_specification_missing_profile_url_error(self):
         validationResult, report = validate(self.rules, self.SOURCES_PATH+"mets_root_element/mets_root_element_profile_url_not_exists.xml")
         self.assertTrue(validationResult==False)
-

--- a/test/test_structmap_premis.py
+++ b/test/test_structmap_premis.py
@@ -1,7 +1,7 @@
-from base import Base
+from test.base import Base
 from metsvalidator.mets_validator_impl import validate
 
-# In this class we test first the correct mets structmap element in PREMIS format and then different error samples. 
+# In this class we test first the correct mets structmap element in PREMIS format and then different error samples.
 # If validation error was detected - validation result should be False.
 class MetsStructMapPremisTestCase(Base):
     """ Tests for METS structmap premis element """
@@ -141,4 +141,3 @@ class MetsStructMapPremisTestCase(Base):
     def test_csip112_check_structmap_premis_element_div_div_representation_mptr_loctype(self):
         validationResult, report = validate(self.rules, self.SOURCES_PATH+"mets_structmap_premis_element/mets_structmap_premis_element_div_div_representation_mptr_loctype_not_exists.xml")
         self.assertTrue(validationResult==True)
-

--- a/validation-api/mets_validator_impl.py
+++ b/validation-api/mets_validator_impl.py
@@ -15,7 +15,7 @@
 #
 #CSIP3: The Information Package folder CAN be compressed (for example by using TAR or ZIP)
 #
-#CSIP4: The Information Package folder MUST include a metadata file named METS.xml, which includes information about the identity and structure of the package and its components 
+#CSIP4: The Information Package folder MUST include a metadata file named METS.xml, which includes information about the identity and structure of the package and its components
 #
 #CSIP5: The Information Package folder MUST include a folder named metadata, which MUST include at least all metadata relevant for the whole package
 #
@@ -27,9 +27,9 @@
 #
 #CSIP9: The Information Package folder MUST include a folder named representations
 #
-#CSIP10: The representations folder MUST include a sub-folder for each individual representation (i.e. the “representation folder”) named with a string uniquely identifying the representation within the scope of the package (for example the name of the representation and/or its creation date could be good examples for an representation sub-folder) 
+#CSIP10: The representations folder MUST include a sub-folder for each individual representation (i.e. the “representation folder”) named with a string uniquely identifying the representation within the scope of the package (for example the name of the representation and/or its creation date could be good examples for an representation sub-folder)
 #
-#CSIP11: The representation folder MUST include a sub-folder named data which includes all data constituting the representation 
+#CSIP11: The representation folder MUST include a sub-folder named data which includes all data constituting the representation
 #
 #CSIP12: The representation folder CAN include a metadata file named METS.xml which includes information about the identity and structure of the representation
 #
@@ -65,15 +65,15 @@ def load_xml(filename):
 
 def validate(rules, sample_file):
     #print (rules, sample_file)
-    f = io.StringIO(unicode(rules))
-    
+    f = io.StringIO(rules)
+
     # Parse schema
     sct_doc = etree.parse(f)
     schematron = isoschematron.Schematron(sct_doc, store_report = True)
 
     # XML to validate
     sample = load_xml(sample_file)
-    isValid = io.StringIO(unicode(sample))
+    isValid = io.StringIO(sample)
 
     # Parse xml
     doc = etree.parse(isValid)
@@ -118,15 +118,15 @@ def main():
 
     # XML to validate
     notValid = io.StringIO('''\
-	<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-	    xmlns:mets="http://www.loc.gov/METS/" 
+	<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xmlns:mets="http://www.loc.gov/METS/"
 	    xmlns:xlink="http://www.w3.org/1999/xlink"
 	    xmlns:csip="DILCIS"
-	    OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182" 
-	    LABEL="Sample CS IP Information Package" 
-	    TYPE="Database" 
-	    csip:CONTENTTYPESPECIFICATION="SIARD3" 	
-	    PROFILE="http://www.eark-project.com/METS/IP.xml" 
+	    OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182"
+	    LABEL="Sample CS IP Information Package"
+	    TYPE="Database"
+	    csip:CONTENTTYPESPECIFICATION="SIARD3"
+	    PROFILE="http://www.eark-project.com/METS/IP.xml"
 	    xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd">
          </mets:mets>
         ''')

--- a/validation-api/specification/specification.py
+++ b/validation-api/specification/specification.py
@@ -18,7 +18,7 @@ class Specification:
     # The spec details in format SpecificationDetails
     details = []
 
-    # The set of validation rules associated with the specification in format Set<ValidationRule> 
+    # The set of validation rules associated with the specification in format Set<ValidationRule>
     rules = []
 
     def get_details(self):
@@ -26,17 +26,17 @@ class Specification:
 
     # parameter in String format
     def is_supported(self, name, version):
-        for detail in self.details:  
-            #print (detail.describe())    
-	    if detail.name == name and detail.version == version:
-                return True
+        for detail in self.details:
+            #print (detail.describe())
+	        if detail.name == name and detail.version == version:
+                    return True
         return False
 
 
     def get_rules():
         return self.rules
 
-    # in SpecificationDetails format 
+    # in SpecificationDetails format
     def add_detail(self, specification_detail):
         self.details.append(specification_detail)
         #self.details = self.details + specification_detail
@@ -47,7 +47,7 @@ class Specification:
         self.rules = self.rules + rule
 
     def describe(self):
-        print 'Specification - details name: %s, details number: %d, rules number: %d' % (self.details[0].name, len(self.details), len(self.rules))
+        print('Specification - details name: %s, details number: %d, rules number: %d' % self.details[0].name, len(self.details), len(self.rules))
 
 
 def main():
@@ -55,7 +55,7 @@ def main():
     # test code
     pass
 
-# this means that if this script is executed, then 
+# this means that if this script is executed, then
 # main() will be executed
 if __name__ == '__main__':
     main()

--- a/validation-api/specification/specification_details.py
+++ b/validation-api/specification/specification_details.py
@@ -36,14 +36,14 @@ class SpecificationDetails:
         self.description = description
 
     def describe(self):
-        print 'Specification details - name: %s, version: %s, location: %s, description: %s' % (self.name, self.version, self.location, self.description)
+        print('Specification details - name: %s, version: %s, location: %s, description: %s' % self.name, self.version, self.location, self.description)
 
 def main():
 
     # test code
     pass
 
-# this means that if this script is executed, then 
+# this means that if this script is executed, then
 # main() will be executed
 if __name__ == '__main__':
     main()

--- a/validation-api/validation_api.py
+++ b/validation-api/validation_api.py
@@ -13,8 +13,8 @@ from argparse import ArgumentParser
 
 import validation
 import specification
-from specification import specification_details 
-from specification import specification 
+from specification import specification_details
+from specification import specification
 import validation_utils
 
 validation_api = None
@@ -41,15 +41,15 @@ class ValidationApi:
 
     # Specification format
     def set_supported_specifications(self, specification):
-	self.specifications.append(specification)
+	    self.specifications.append(specification)
 
-    # returns a list of specification summaries Set<SpecificationDetails> 
+    # returns a list of specification summaries Set<SpecificationDetails>
     def get_supported_specification_summaries(self):
         return self.specifications_details
 
-    # SpecificationDetails format 
+    # SpecificationDetails format
     def set_supported_specification_summaries(self, specification_detail):
-	self.specifications_details.append(specification_detail)
+	    self.specifications_details.append(specification_detail)
 
     # return specification of type Specification by String values
     def get_specification(self, spec_name, spec_version):
@@ -73,7 +73,7 @@ class ValidationApi:
     #def validate(SpecificationDetails spec, InputStream packageStream):
     #    pass
 
-    # Method to validate packages in a directory. Retuns result in format ValidationResult using 
+    # Method to validate packages in a directory. Retuns result in format ValidationResult using
     # SpecificationDetails and package root as a Sting
     def validate(self, spec, package_root, validation_rule_path):
         return validation_utils.validate(spec, package_root, validation_rule_path)
@@ -145,17 +145,17 @@ def main():
         print ("create validation rules and add it to specification ...")
         validation_rules = validation_utils.read_rules(validation_rule_path)
         specification_obj.add_rule(validation_rules)
-   
+
         supported_specifications = validation_api.get_supported_specifications()
         for spec in supported_specifications:
-	    spec.describe()
-   
+	        spec.describe()
+
         for summary in validation_api.get_supported_specification_summaries():
-	    summary.describe()
+	        summary.describe()
 
         check_spec = validation_api.get_specification(supported_specifications[0].get_details()[0].name, supported_specifications[0].get_details()[0].version)
-        print 'got specification: '
-        print check_spec.describe()
+        print('got specification: ')
+        print(check_spec.describe())
 
         supported = validation_api.is_supported(supported_specifications[0].get_details()[0].name, supported_specifications[0].get_details()[0].version)
         print ("specification is supported", supported)
@@ -169,24 +169,22 @@ def main():
     elif api_type == 'getspecs':
         supported_specifications = validation_api.get_supported_specifications()
         for spec in supported_specifications:
-	    print ("supported specification", spec.describe())
+            print("supported specification %s", spec.describe())
     elif api_type == 'getspecsummaries':
         supported_specification_summaries = validation_api.get_supported_specification_summaries()
         for summary in validation_api.supported_specification_summaries:
-	    print ("supported specification summary", summary.describe())
+	        print("supported specification summary", summary.describe())
     elif api_type == 'issupported':
         supported = validation_api.is_supported(specification.name, specification.version)
-        print ("specification is supported", supported)
+        print("specification is supported", supported)
     elif api_type == 'getversion':
-        print '%s %10s' %("validation API version", validation_api.get_version())
+        print('%s %10s' % "validation API version", validation_api.get_version())
     elif api_type == 'validate':
-        print ("validate package ...")
+        print("validate package ...")
         validation_result = validation_api.validate(specification, package_root)
         validation_result.describe()
 
-# this means that if this script is executed, then 
+# this means that if this script is executed, then
 # main() will be executed
 if __name__ == '__main__':
     main()
-
-

--- a/validation-api/validation_utils.py
+++ b/validation-api/validation_utils.py
@@ -10,9 +10,9 @@
 # about the terms of this license.
 
 from xml.dom import minidom
-import specification
-import validation
-from validation import validation_rule, validation_result
+# import specification
+# import validation
+# from validation import validation_rule, validation_result
 
 # XML field names
 RULE = 'rule'
@@ -31,11 +31,11 @@ def read_rules(path):
 
     xml_validation_rule = parse_xml(path)
     itemlist = xml_validation_rule.getElementsByTagName(RULE)
-    print "%s: %10d" %("rules",len(itemlist))
+    print("%s: %10d" % "rules", len(itemlist))
     for item in itemlist:
-        print '%s: %20s' % (ID, item.attributes[ID].value)
-        print '%s: %20s' % (TEST, item.getElementsByTagName(ASSERT)[0].attributes[TEST].value)
-        print '%s: %20s' % (MESSAGE, list(item.getElementsByTagName(ASSERT))[0].firstChild.data)
+        print('%s: %20s' % ID, item.attributes[ID].value)
+        print('%s: %20s' % TEST, item.getElementsByTagName(ASSERT)[0].attributes[TEST].value)
+        print('%s: %20s' % MESSAGE, list(item.getElementsByTagName(ASSERT))[0].firstChild.data)
 
         validation_rule_obj = validation_rule.ValidationRule()
         validation_rule_obj.id = item.attributes[ID].value
@@ -44,66 +44,66 @@ def read_rules(path):
         validation_rule_obj.description = item.getElementsByTagName(ASSERT)[0].attributes[TEST].value
         rules.append(validation_rule_obj)
     return rules
-    
+
 # this method parses archive package xml file. Path parameter is in String format
 def read_archive(path):
 
     print ("validation: read archive package")
     xml_archive = parse_xml(path)
     itemlist = xml_archive.getElementsByTagName("mets:digiprovMD")
-    print "%s: %10d" %("archive items",len(itemlist))
+    print("%s: %10d" % "archive items",len(itemlist))
     for item in itemlist:
-        print '%s: %20s' % (ID, item.attributes["ID"].value)
-        print '%s: %20s' % ("CREATED", item.attributes["CREATED"].value)
-        print '%s: %20s' % ("LOCTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["LOCTYPE"].value)
-        print '%s: %20s' % ("type", item.getElementsByTagName("mets:mdRef")[0].attributes["type"].value)
-        print '%s: %20s' % ("href", item.getElementsByTagName("mets:mdRef")[0].attributes["href"].value)
-        print '%s: %20s' % ("MDTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["MDTYPE"].value)
-        print '%s: %20s' % ("MDTYPEVERSION", item.getElementsByTagName("mets:mdRef")[0].attributes["MDTYPEVERSION"].value)
-        print '%s: %20s' % ("MIMETYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["MIMETYPE"].value)
-        print '%s: %20s' % ("SIZE", item.getElementsByTagName("mets:mdRef")[0].attributes["SIZE"].value)
-        print '%s: %20s' % ("CREATED", item.getElementsByTagName("mets:mdRef")[0].attributes["CREATED"].value)
-        print '%s: %20s' % ("CHECKSUM", item.getElementsByTagName("mets:mdRef")[0].attributes["CHECKSUM"].value)
-        print '%s: %20s' % ("CHECKSUMTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["CHECKSUMTYPE"].value)
-        print '%s: %20s' % ("LABEL", item.getElementsByTagName("mets:mdRef")[0].attributes["LABEL"].value)
-    
+        print('%s: %20s' % ID, item.attributes["ID"].value)
+        print('%s: %20s' % "CREATED", item.attributes["CREATED"].value)
+        print('%s: %20s' % "LOCTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["LOCTYPE"].value)
+        print('%s: %20s' % "type", item.getElementsByTagName("mets:mdRef")[0].attributes["type"].value)
+        print('%s: %20s' % "href", item.getElementsByTagName("mets:mdRef")[0].attributes["href"].value)
+        print('%s: %20s' % "MDTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["MDTYPE"].value)
+        print('%s: %20s' % "MDTYPEVERSION", item.getElementsByTagName("mets:mdRef")[0].attributes["MDTYPEVERSION"].value)
+        print('%s: %20s' % "MIMETYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["MIMETYPE"].value)
+        print('%s: %20s' % "SIZE", item.getElementsByTagName("mets:mdRef")[0].attributes["SIZE"].value)
+        print('%s: %20s' % "CREATED", item.getElementsByTagName("mets:mdRef")[0].attributes["CREATED"].value)
+        print('%s: %20s' % "CHECKSUM", item.getElementsByTagName("mets:mdRef")[0].attributes["CHECKSUM"].value)
+        print('%s: %20s' % "CHECKSUMTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["CHECKSUMTYPE"].value)
+        print('%s: %20s' % "LABEL", item.getElementsByTagName("mets:mdRef")[0].attributes["LABEL"].value)
+
 # this method parses specification package xml file. Path parameter is in String format
 def read_specification(path):
 
     print ("validation: read specification")
     xml_archive = parse_xml(path)
     itemlist = xml_archive.getElementsByTagName("mets:digiprovMD")
-    print "%s: %10d" %("specificaton items",len(itemlist))
+    print("%s: %10d" % "specificaton items",len(itemlist))
     for item in itemlist:
-        print '%s: %20s' % (ID, item.attributes["ID"].value)
-        print '%s: %20s' % ("CREATED", item.attributes["CREATED"].value)
-        print '%s: %20s' % ("LOCTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["LOCTYPE"].value)
-        print '%s: %20s' % ("type", item.getElementsByTagName("mets:mdRef")[0].attributes["type"].value)
-        print '%s: %20s' % ("href", item.getElementsByTagName("mets:mdRef")[0].attributes["href"].value)
-        print '%s: %20s' % ("MDTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["MDTYPE"].value)
-        print '%s: %20s' % ("MDTYPEVERSION", item.getElementsByTagName("mets:mdRef")[0].attributes["MDTYPEVERSION"].value)
-        print '%s: %20s' % ("MIMETYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["MIMETYPE"].value)
-        print '%s: %20s' % ("SIZE", item.getElementsByTagName("mets:mdRef")[0].attributes["SIZE"].value)
-        print '%s: %20s' % ("CREATED", item.getElementsByTagName("mets:mdRef")[0].attributes["CREATED"].value)
-        print '%s: %20s' % ("CHECKSUM", item.getElementsByTagName("mets:mdRef")[0].attributes["CHECKSUM"].value)
-        print '%s: %20s' % ("CHECKSUMTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["CHECKSUMTYPE"].value)
-        print '%s: %20s' % ("LABEL", item.getElementsByTagName("mets:mdRef")[0].attributes["LABEL"].value)
+        print('%s: %20s' % ID, item.attributes["ID"].value)
+        print('%s: %20s' % "CREATED", item.attributes["CREATED"].value)
+        print('%s: %20s' % "LOCTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["LOCTYPE"].value)
+        print('%s: %20s' % "type", item.getElementsByTagName("mets:mdRef")[0].attributes["type"].value)
+        print('%s: %20s' % "href", item.getElementsByTagName("mets:mdRef")[0].attributes["href"].value)
+        print('%s: %20s' % "MDTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["MDTYPE"].value)
+        print('%s: %20s' % "MDTYPEVERSION", item.getElementsByTagName("mets:mdRef")[0].attributes["MDTYPEVERSION"].value)
+        print('%s: %20s' % "MIMETYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["MIMETYPE"].value)
+        print('%s: %20s' % "SIZE", item.getElementsByTagName("mets:mdRef")[0].attributes["SIZE"].value)
+        print('%s: %20s' % "CREATED", item.getElementsByTagName("mets:mdRef")[0].attributes["CREATED"].value)
+        print('%s: %20s' % "CHECKSUM", item.getElementsByTagName("mets:mdRef")[0].attributes["CHECKSUM"].value)
+        print('%s: %20s' % "CHECKSUMTYPE", item.getElementsByTagName("mets:mdRef")[0].attributes["CHECKSUMTYPE"].value)
+        print('%s: %20s' % "LABEL", item.getElementsByTagName("mets:mdRef")[0].attributes["LABEL"].value)
 
 def extract_specification_name(specification_location):
-   
+
     location_folders = specification_location.split('/')
     return location_folders[-2]
 
 
-# this mathod validates archive package according to the provided specification 
-# and returns ValidationResult. 
+# this mathod validates archive package according to the provided specification
+# and returns ValidationResult.
 # Specification parameter is given in SpecificationDetails format. Path parameter is a String
 def validate(spec, path, validation_rule_path):
-    
+
     read_archive(path)
     #read_specification(spec.location)
-    
-    print 'validation rule path: %s' % (validation_rule_path)
+
+    print('validation rule path: %s' % validation_rule_path)
     # call validation package
     #from base import Base
 #    import sys
@@ -131,7 +131,7 @@ def main():
     # test code
     pass
 
-# this means that if this script is executed, then 
+# this means that if this script is executed, then
 # main() will be executed
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- updated package name in `setup.py`;
- removed some non-functioning / unused `import`s;
- fixed indentation errors;
- updated `print` statements to Python3 style;
- removed `unicode` references;
- fixed some `import` statements;
- removed trailing newlines; and
- `.gitignore`d `egg-info` and `venv` files.